### PR TITLE
Feature: Implements a Dedicated API Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/bin
 node_modules
 frontend/dist
 .idea
+.vscode
 config.json
 cookies.json
 /test

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.21.1
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
 	github.com/dlclark/regexp2 v1.10.0
+	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-resty/resty/v2 v2.10.0
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=

--- a/webapi/README.md
+++ b/webapi/README.md
@@ -15,6 +15,7 @@ Then the server will be running at <http://localhost:8080>.
 - `NO_LOG`: Whether to disable logging. Default: `false`
 - `DEFAULT_COOKIES`: Default cookies to use, can be obtained by `document.cookie`. Default: `""`
 - `HTTPS_PROXY` or `HTTP_PROXY`: The proxy to use for requests to Microsoft. Default: `""`
+- `AUTH_TOKEN`: The Bearer token to access the API server. Default: `""`
 
 ## Endpoints
 
@@ -65,3 +66,7 @@ Start a chat stream.
   - Body: Server-sent events
     - `event`: `string`
     - `data`: `string`
+
+### POST /v1/chat/completions
+
+This endpoint is compatible with the OpenAI API. You can check the API reference [here](https://platform.openai.com/docs/api-reference/chat).

--- a/webapi/README.md
+++ b/webapi/README.md
@@ -1,0 +1,67 @@
+# Sydney Web API
+
+## Quick Start
+
+```bash
+go run ./webapi
+```
+
+Then the server will be running at <http://localhost:8080>.
+
+## Environment Variables
+
+- `PORT`: The port to listen on. Default: `8080`
+- `ALLOWED_ORIGINS`: The allowed origins for CORS. Default: `*`
+- `NO_LOG`: Whether to disable logging. Default: `false`
+- `DEFAULT_COOKIES`: Default cookies to use, can be obtained by `document.cookie`. Default: `""`
+- `HTTPS_PROXY` or `HTTP_PROXY`: The proxy to use for requests to Microsoft. Default: `""`
+
+## Endpoints
+
+### POST /conversation/new
+
+Create a new conversation.
+
+- **Request**:
+  - Content-Type: `application/json`
+  - Body:
+    - `cookies`: `string` (Optional)
+- **Response**:
+  - Content-Type: `application/json`
+  - Body: `CreateConversationResponse`
+
+### POST /image/upload
+
+Upload an image and return its URL.
+
+- **Request**:
+  - Content-Type: `multipart/form-data`
+  - Body:
+    - `image`: `File`
+    - `cookies`: `string` (Optional)
+
+- **Response**:
+  - Content-Type: `text/plain`
+  - Body: `string`
+
+### POST /chat/stream
+
+Start a chat stream.
+
+- **Request**:
+  - Content-Type: `application/json`
+  - Body:
+    - `conversation`
+    - `prompt`: `string`
+    - `context`: `string`
+    - `cookies`: `string` (Optional)
+    - `imageUrl`: `string` (Optional)
+    - `noSearch`: `boolean` (Optional)
+    - `conversationStyle`: `string` (Optional)
+    - `locale`: `string` (Optional)
+
+- **Response**:
+  - Content-Type: `text/event-stream`
+  - Body: Server-sent events
+    - `event`: `string`
+    - `data`: `string`

--- a/webapi/README.md
+++ b/webapi/README.md
@@ -52,7 +52,7 @@ Start a chat stream.
 - **Request**:
   - Content-Type: `application/json`
   - Body:
-    - `conversation`
+    - `conversation`: `CreateConversationResponse`
     - `prompt`: `string`
     - `context`: `string`
     - `cookies`: `string` (Optional)
@@ -70,3 +70,17 @@ Start a chat stream.
 ### POST /v1/chat/completions
 
 This endpoint is compatible with the OpenAI API. You can check the API reference [here](https://platform.openai.com/docs/api-reference/chat).
+
+Due to differences between the OpenAI API and the Sydney API, only the following parameters are supported:
+
+- `messages`: The same as OpenAI's, and can contain image url (only valid in the last message).
+- `model`: `GPT-3.5-Turbo` series will be mapped to `Balance`, others will be mapped to `Creative`.
+- `stream`: The same as OpenAI's.
+
+There is an extra field or reusing conversation, if your SDK supports such customization:
+
+- `conversation`: `CreateConversationResponse`
+
+The `Cookie` header is also supported to provide custom cookies.
+
+The response is full of dummy values, and only the `choices` field is valid. The stop reason is `length` if any error occurs, and `stop` otherwise.

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -61,39 +61,49 @@ type OpenAIChatCompletionRequest struct {
 	Conversation sydney.CreateConversationResponse `json:"conversation,omitempty"`
 }
 
-type OpenAIChatCompletionChunk []struct {
-	ID                string `json:"id"`
-	Object            string `json:"object"`
-	Created           int    `json:"created"`
-	Model             string `json:"model"`
-	SystemFingerprint string `json:"system_fingerprint"`
-	Choices           []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"delta"`
-		FinishReason *string `json:"finish_reason"`
-	} `json:"choices"`
+type ChoiceDelta struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
 }
 
-type OpenAIChatCompletion []struct {
-	ID                string `json:"id"`
-	Object            string `json:"object"`
-	Created           int    `json:"created"`
-	Model             string `json:"model"`
-	SystemFingerprint string `json:"system_fingerprint"`
-	Choices           []struct {
-		Index int `json:"index"`
-		Delta struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
-		} `json:"delta"`
-		FinishReason *string `json:"finish_reason"`
-	} `json:"choices"`
-	Usage struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
-		TotalTokens      int `json:"total_tokens"`
-	} `json:"usage"`
+type ChatCompletionChunkChoice struct {
+	Index        int         `json:"index"`
+	Delta        ChoiceDelta `json:"delta"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type OpenAIChatCompletionChunk struct {
+	ID                string                      `json:"id"`
+	Object            string                      `json:"object"`
+	Created           int64                       `json:"created"`
+	Model             string                      `json:"model"`
+	SystemFingerprint string                      `json:"system_fingerprint"`
+	Choices           []ChatCompletionChunkChoice `json:"choices"`
+}
+
+type ChoiceMessage struct {
+	Content string `json:"content"`
+	Role    string `json:"role"`
+}
+
+type UsageStats struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type ChatCompletionChoice struct {
+	Index        int           `json:"index"`
+	Message      ChoiceMessage `json:"message"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+type OpenAIChatCompletion struct {
+	ID                string                 `json:"id"`
+	Object            string                 `json:"object"`
+	Created           int64                  `json:"created"`
+	Model             string                 `json:"model"`
+	SystemFingerprint string                 `json:"system_fingerprint"`
+	Choices           []ChatCompletionChoice `json:"choices"`
+	Usage             UsageStats             `json:"usage"`
 }

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -1,0 +1,18 @@
+package main
+
+import "sydneyqt/sydney"
+
+type CreateConversationRequest struct {
+	Cookies string `json:"cookies,omitempty"`
+}
+
+type ChatStreamRequest struct {
+	Conversation      sydney.CreateConversationResponse `json:"conversation"`
+	Prompt            string                            `json:"prompt"`
+	WebpageContext    string                            `json:"context"`
+	Cookies           string                            `json:"cookies,omitempty"`
+	ImageURL          string                            `json:"imageUrl,omitempty"`
+	NoSearch          bool                              `json:"noSearch,omitempty"`
+	ConversationStyle string                            `json:"conversationStyle,omitempty"`
+	Locale            string                            `json:"locale,omitempty"`
+}

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -18,7 +18,6 @@ type ChatStreamRequest struct {
 }
 
 // The `content` field can have different types
-// So we use a map instead of a struct
 // Example:
 //
 //	{
@@ -43,7 +42,10 @@ type ChatStreamRequest struct {
 //			}
 //		]
 //	}
-type OpenAIMessage map[string]interface{}
+type OpenAIMessage struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"`
+}
 
 type OpenAIMessagesParseResult struct {
 	WebpageContext string

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -16,3 +16,81 @@ type ChatStreamRequest struct {
 	ConversationStyle string                            `json:"conversationStyle,omitempty"`
 	Locale            string                            `json:"locale,omitempty"`
 }
+
+// The `content` field can have different types
+// So we use a map instead of a struct
+// Example:
+//
+//	{
+//		"role": "user",
+//		"content": "Hello!"
+//	}
+//
+// or
+//
+//	{
+//		"role": "user",
+//		"content": [
+//			{
+//				"type": "text",
+//				"text": "What’s in this image?"
+//			},
+//			{
+//				"type": "image_url",
+//				"image_url": {
+//					"url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+//				}
+//			}
+//		]
+//	}
+type OpenAIMessage map[string]interface{}
+
+type OpenAIMessagesParseResult struct {
+	WebpageContext string
+	Prompt         string
+	ImageURL       string
+}
+
+// Most fields are omitted due to limitations of the Bing API
+type OpenAIChatCompletionRequest struct {
+	Model    string          `json:"model"`
+	Messages []OpenAIMessage `json:"messages"`
+	Stream   bool            `json:"stream"`
+}
+
+type OpenAIChatCompletionChunk []struct {
+	ID                string `json:"id"`
+	Object            string `json:"object"`
+	Created           int    `json:"created"`
+	Model             string `json:"model"`
+	SystemFingerprint string `json:"system_fingerprint"`
+	Choices           []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+}
+
+type OpenAIChatCompletion []struct {
+	ID                string `json:"id"`
+	Object            string `json:"object"`
+	Created           int    `json:"created"`
+	Model             string `json:"model"`
+	SystemFingerprint string `json:"system_fingerprint"`
+	Choices           []struct {
+		Index int `json:"index"`
+		Delta struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -69,7 +69,7 @@ type ChoiceDelta struct {
 type ChatCompletionChunkChoice struct {
 	Index        int         `json:"index"`
 	Delta        ChoiceDelta `json:"delta"`
-	FinishReason string      `json:"finish_reason"`
+	FinishReason *string      `json:"finish_reason"`
 }
 
 type OpenAIChatCompletionChunk struct {

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -55,9 +55,10 @@ type OpenAIMessagesParseResult struct {
 
 // Most fields are omitted due to limitations of the Bing API
 type OpenAIChatCompletionRequest struct {
-	Model    string          `json:"model"`
-	Messages []OpenAIMessage `json:"messages"`
-	Stream   bool            `json:"stream"`
+	Model        string                            `json:"model"`
+	Messages     []OpenAIMessage                   `json:"messages"`
+	Stream       bool                              `json:"stream"`
+	Conversation sydney.CreateConversationResponse `json:"conversation,omitempty"`
 }
 
 type OpenAIChatCompletionChunk []struct {

--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -6,8 +6,7 @@ import (
 )
 
 var (
-	ErrInvalidOpenAIMessage = errors.New("invalid openai message")
-	ErrUnknownPrompt        = errors.New("unknown prompt")
+	ErrMissingPrompt = errors.New("user prompt is missing (last message is not sent by user)")
 )
 
 func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, error) {
@@ -20,7 +19,7 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 	prompt, imageUrl := ParseOpenAIMessageContent(lastMessage.Content)
 
 	if lastMessage.Role != "user" || prompt == "" {
-		return OpenAIMessagesParseResult{}, ErrUnknownPrompt
+		return OpenAIMessagesParseResult{}, ErrMissingPrompt
 	}
 
 	// construct context

--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -22,6 +22,13 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 		return OpenAIMessagesParseResult{}, ErrMissingPrompt
 	}
 
+	if len(messages) == 1 {
+		return OpenAIMessagesParseResult{
+			Prompt:   prompt,
+			ImageURL: imageUrl,
+		}, nil
+	}
+
 	// construct context
 	var contextBuilder strings.Builder
 	contextBuilder.WriteString("\n\n")

--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -25,6 +25,7 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 
 	// construct context
 	var contextBuilder strings.Builder
+	contextBuilder.WriteString("\n\n")
 
 	for i, message := range messages[:len(messages)-1] {
 		// assert types
@@ -59,11 +60,9 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 }
 
 func parseOpenAIMessage(message OpenAIMessage) (role, text, imageUrl string) {
-	if msgRole, ok := message["role"].(string); ok {
-		role = msgRole
-	}
+	role = message.Role
 
-	switch content := message["content"].(type) {
+	switch content := message.Content.(type) {
 	case string:
 		// content is string, and it automatically becomes prompt
 		text = content

--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	ErrInvalidOpenAIMessage = errors.New("invalid openai message")
+	ErrUnknownPrompt        = errors.New("unknown prompt")
+)
+
+func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, error) {
+	if len(messages) == 0 {
+		return OpenAIMessagesParseResult{}, nil
+	}
+
+	// last message must be user prompt
+	lastMessage := messages[len(messages)-1]
+	role, prompt, imageUrl := parseOpenAIMessage(lastMessage)
+
+	if role != "user" || prompt == "" {
+		return OpenAIMessagesParseResult{}, ErrUnknownPrompt
+	}
+
+	// construct context
+	var contextBuilder strings.Builder
+
+	for i, message := range messages[:len(messages)-1] {
+		// assert types
+		role, text, _ := parseOpenAIMessage(message)
+
+		if role == "" || text == "" {
+			return OpenAIMessagesParseResult{}, ErrInvalidOpenAIMessage
+		}
+
+		// append role to context
+		switch role {
+		case "user":
+			contextBuilder.WriteString("[user](#message)\n")
+		case "assistant":
+			contextBuilder.WriteString("[assistant](#message)\n")
+		case "system":
+			contextBuilder.WriteString("[system](#additional_instructions)\n")
+		}
+
+		// append content to context
+		contextBuilder.WriteString(text)
+		if i != len(messages)-2 {
+			contextBuilder.WriteString("\n\n")
+		}
+	}
+
+	return OpenAIMessagesParseResult{
+		Prompt:         prompt,
+		WebpageContext: contextBuilder.String(),
+		ImageURL:       imageUrl,
+	}, nil
+}
+
+func parseOpenAIMessage(message OpenAIMessage) (role, text, imageUrl string) {
+	if msgRole, ok := message["role"].(string); ok {
+		role = msgRole
+	}
+
+	switch content := message["content"].(type) {
+	case string:
+		// content is string, and it automatically becomes prompt
+		text = content
+	case []map[string]interface{}:
+		// content is array of objects, and it contains prompt and optional image url
+		for _, content := range content {
+			switch content["type"] {
+			case "text":
+				if contentText, ok := content["text"].(string); ok {
+					text = contentText
+				}
+			case "image_url":
+				if url, ok := content["image_url"].(map[string]string); ok {
+					imageUrl = url["url"]
+				}
+			}
+		}
+	}
+
+	return
+}

--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -3,10 +3,13 @@ package main
 import (
 	"errors"
 	"strings"
+	"time"
 )
 
 var (
-	ErrMissingPrompt = errors.New("user prompt is missing (last message is not sent by user)")
+	ErrMissingPrompt   = errors.New("user prompt is missing (last message is not sent by user)")
+	FinishReasonStop   = "stop"
+	FinishReasonLength = "length"
 )
 
 func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, error) {
@@ -85,4 +88,29 @@ func ParseOpenAIMessageContent(content interface{}) (text, imageUrl string) {
 	}
 
 	return
+}
+
+func NewOpenAIChatCompletion(model, content, finishReason string) *OpenAIChatCompletion {
+	return &OpenAIChatCompletion{
+		ID:                "chatcmpl-123",
+		Object:            "chat.completion",
+		Created:           time.Now().Unix(),
+		Model:             model,
+		SystemFingerprint: "fp_44709d6fcb",
+		Choices: []ChatCompletionChoice{
+			{
+				Index: 0,
+				Message: ChoiceMessage{
+					Role:    "assistant",
+					Content: content,
+				},
+				FinishReason: finishReason,
+			},
+		},
+		Usage: UsageStats{
+			PromptTokens:     1024,
+			CompletionTokens: 1024,
+			TotalTokens:      2048,
+		},
+	}
 }

--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -114,3 +114,23 @@ func NewOpenAIChatCompletion(model, content, finishReason string) *OpenAIChatCom
 		},
 	}
 }
+
+func NewOpenAIChatCompletionChunk(model, delta string, finishReason *string) *OpenAIChatCompletionChunk {
+	return &OpenAIChatCompletionChunk{
+		ID:                "chatcmpl-123",
+		Object:            "chat.completion",
+		Created:           time.Now().Unix(),
+		Model:             model,
+		SystemFingerprint: "fp_44709d6fcb",
+		Choices: []ChatCompletionChunkChoice{
+			{
+				Index: 0,
+				Delta: ChoiceDelta{
+					Role:    "assistant",
+					Content: delta,
+				},
+				FinishReason: finishReason,
+			},
+		},
+	}
+}

--- a/webapi/openai_test.go
+++ b/webapi/openai_test.go
@@ -10,26 +10,20 @@ func TestParseOpenAIMessages(t *testing.T) {
 	t.Run("valid with image", func(t *testing.T) {
 		messages := []OpenAIMessage{
 			{
-				"role": "user",
-				"content": []map[string]interface{}{
-					{
-						"type": "text",
-						"text": "Hello!",
-					},
-				},
+				Role:    "system",
+				Content: "You are Sydney.",
 			},
 			{
-				"role": "assistant",
-				"content": []map[string]interface{}{
-					{
-						"type": "text",
-						"text": "Hi!",
-					},
-				},
+				Role:    "user",
+				Content: "Hello!",
 			},
 			{
-				"role": "user",
-				"content": []map[string]interface{}{
+				Role:    "assistant",
+				Content: "Hi!",
+			},
+			{
+				Role: "user",
+				Content: []map[string]interface{}{
 					{
 						"type": "text",
 						"text": "How are you?",
@@ -47,7 +41,7 @@ func TestParseOpenAIMessages(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, OpenAIMessagesParseResult{
 			Prompt:         "How are you?",
-			WebpageContext: "[user](#message)\nHello!\n\n[assistant](#message)\nHi!",
+			WebpageContext: "\n\n[system](#additional_instructions)\nYou are Sydney.\n\n[user](#message)\nHello!\n\n[assistant](#message)\nHi!",
 			ImageURL:       "https://example.com/image.jpg",
 		}, result)
 	})

--- a/webapi/openai_test.go
+++ b/webapi/openai_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseOpenAIMessages(t *testing.T) {
+	t.Run("valid with image", func(t *testing.T) {
+		messages := []OpenAIMessage{
+			{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{
+						"type": "text",
+						"text": "Hello!",
+					},
+				},
+			},
+			{
+				"role": "assistant",
+				"content": []map[string]interface{}{
+					{
+						"type": "text",
+						"text": "Hi!",
+					},
+				},
+			},
+			{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{
+						"type": "text",
+						"text": "How are you?",
+					},
+					{
+						"type": "image_url",
+						"image_url": map[string]string{
+							"url": "https://example.com/image.jpg",
+						},
+					},
+				},
+			},
+		}
+		result, err := ParseOpenAIMessages(messages)
+		assert.Nil(t, err)
+		assert.Equal(t, OpenAIMessagesParseResult{
+			Prompt:         "How are you?",
+			WebpageContext: "[user](#message)\nHello!\n\n[assistant](#message)\nHi!",
+			ImageURL:       "https://example.com/image.jpg",
+		}, result)
+	})
+}

--- a/webapi/openai_test.go
+++ b/webapi/openai_test.go
@@ -7,6 +7,24 @@ import (
 )
 
 func TestParseOpenAIMessages(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		result, err := ParseOpenAIMessages([]OpenAIMessage{})
+		assert.Nil(t, err)
+		assert.Equal(t, OpenAIMessagesParseResult{}, result)
+	})
+	t.Run("single message", func(t *testing.T) {
+		messages := []OpenAIMessage{
+			{
+				Role:    "user",
+				Content: "Hello!",
+			},
+		}
+		result, err := ParseOpenAIMessages(messages)
+		assert.Nil(t, err)
+		assert.Equal(t, OpenAIMessagesParseResult{
+			Prompt: "Hello!",
+		}, result)
+	})
 	t.Run("valid with image", func(t *testing.T) {
 		messages := []OpenAIMessage{
 			{

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -1,6 +1,8 @@
 package main
 
-import "strings"
+import (
+	"strings"
+)
 
 func ParseCookies(cookiesStr string) map[string]string {
 	cookies := map[string]string{}

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -1,0 +1,14 @@
+package main
+
+import "strings"
+
+func ParseCookies(cookiesStr string) map[string]string {
+	cookies := map[string]string{}
+	for _, cookie := range strings.Split(cookiesStr, ";") {
+		parts := strings.Split(cookie, "=")
+		if len(parts) == 2 {
+			cookies[parts[0]] = parts[1]
+		}
+	}
+	return cookies
+}

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -149,8 +149,8 @@ func main() {
 
 		// write response
 		for message := range messageCh {
-			fmt.Fprintf(w, "event: %s\n", message.Type)
-			fmt.Fprintf(w, "data: %s\n\n", message.Text)
+			encoded, _ := json.Marshal(message.Text)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", message.Type, encoded)
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sydneyqt/sydney"
+	"sydneyqt/util"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func main() {
+	// read envs
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	proxy := os.Getenv("HTTPS_PROXY")
+	if proxy == "" {
+		proxy = os.Getenv("HTTP_PROXY")
+	}
+
+	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
+	if allowedOrigins == "" {
+		allowedOrigins = "*"
+	}
+
+	noLog := os.Getenv("NO_LOG") != ""
+
+	defaultCookies := ParseCookies(os.Getenv("DEFAULT_COOKIES"))
+
+	// create router
+	r := chi.NewRouter()
+
+	// set middleware
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.RealIP)
+	if !noLog {
+		r.Use(middleware.Logger)
+	}
+	r.Use(middleware.SetHeader("Access-Control-Allow-Origin", allowedOrigins))
+
+	// add handlers
+	r.Post("/conversation/new", func(w http.ResponseWriter, r *http.Request) {
+		// parse request
+		var request CreateConversationRequest
+
+		err := json.NewDecoder(r.Body).Decode(&request)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		cookies := util.Ternary(request.Cookies == "", defaultCookies, ParseCookies(request.Cookies))
+
+		// create conversation
+		conversation, err := sydney.
+			NewSydney(false, cookies, proxy, "", "", "", "", false).
+			CreateConversation()
+
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// set headers
+		w.Header().Set("Content-Type", "application/json")
+
+		// write response
+		json.NewEncoder(w).Encode(conversation)
+	})
+
+	r.Post("/image/upload", func(w http.ResponseWriter, r *http.Request) {
+		// parse request
+		r.ParseMultipartForm(16 << 20)
+
+		cookiesStr := r.FormValue("cookies")
+		cookies := util.Ternary(cookiesStr == "", defaultCookies, ParseCookies(cookiesStr))
+
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+
+		bytes, err := io.ReadAll(file)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// upload image
+		imgUrl, err := sydney.
+			NewSydney(false, cookies, proxy, "Creative", "", "", "", false).
+			UploadImage(bytes)
+
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// set headers
+		w.Header().Set("Content-Type", "text/plain")
+
+		// write response
+		fmt.Fprint(w, imgUrl)
+	})
+
+	r.Post("/chat/stream", func(w http.ResponseWriter, r *http.Request) {
+		// parse request
+		request := ChatStreamRequest{
+			ConversationStyle: "Creative",
+		}
+
+		err := json.NewDecoder(r.Body).Decode(&request)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		cookies := util.Ternary(request.Cookies == "", defaultCookies, ParseCookies(request.Cookies))
+
+		if len(request.Locale) != 5 {
+			request.Locale = "en-US"
+		}
+
+		// stream chat
+		messageCh := sydney.
+			NewSydney(false, cookies, proxy, request.ConversationStyle, request.Locale, "", "", request.NoSearch).
+			AskStream(sydney.AskStreamOptions{
+				StopCtx:        r.Context(),
+				Conversation:   request.Conversation,
+				Prompt:         request.Prompt,
+				WebpageContext: request.WebpageContext,
+				ImageURL:       request.ImageURL,
+			})
+
+		// set headers
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		// write response
+		for message := range messageCh {
+			fmt.Fprintf(w, "event: %s\n", message.Type)
+			fmt.Fprintf(w, "data: %s\n\n", message.Text)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	})
+
+	// serve the router
+	log.Println("Listening on :" + port)
+	log.Fatal(http.ListenAndServe(":"+port, r))
+}


### PR DESCRIPTION
This pull request implements a dedicated API Server which can be further used with other front-ends or in other applications. Thanks to the solid foundation of the existing `sydney` implementation, only minimal works have to be done in the API Server.

It comes with a README file which may be useful: <https://github.com/PeronGH/SydneyWeb/blob/go_web/webapi/README.md>