### PR TITLE
Allow empty conversation field in `ChatStreamRequest`

### DIFF
--- a/webapi/README.md
+++ b/webapi/README.md
@@ -52,9 +52,9 @@ Start a chat stream.
 - **Request**:
   - Content-Type: `application/json`
   - Body:
-    - `conversation`: `CreateConversationResponse`
     - `prompt`: `string`
     - `context`: `string`
+    - `conversation`: `CreateConversationResponse` (Optional)
     - `cookies`: `string` (Optional)
     - `imageUrl`: `string` (Optional)
     - `noSearch`: `boolean` (Optional)

--- a/webapi/models.go
+++ b/webapi/models.go
@@ -7,9 +7,9 @@ type CreateConversationRequest struct {
 }
 
 type ChatStreamRequest struct {
-	Conversation      sydney.CreateConversationResponse `json:"conversation"`
 	Prompt            string                            `json:"prompt"`
 	WebpageContext    string                            `json:"context"`
+	Conversation      sydney.CreateConversationResponse `json:"conversation,omitempty"`
 	Cookies           string                            `json:"cookies,omitempty"`
 	ImageURL          string                            `json:"imageUrl,omitempty"`
 	NoSearch          bool                              `json:"noSearch,omitempty"`

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -163,16 +163,25 @@ func main() {
 			request.Locale = "en-US"
 		}
 
+		sydneyAPI := sydney.NewSydney(false, cookies, proxy, request.ConversationStyle, request.Locale, "", "", request.NoSearch)
+
+		// create new conversation if not provided
+		if request.Conversation.ConversationId == "" {
+			request.Conversation, err = sydneyAPI.CreateConversation()
+			if err != nil {
+				http.Error(w, "error creating conversation: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
 		// stream chat
-		messageCh := sydney.
-			NewSydney(false, cookies, proxy, request.ConversationStyle, request.Locale, "", "", request.NoSearch).
-			AskStream(sydney.AskStreamOptions{
-				StopCtx:        r.Context(),
-				Conversation:   request.Conversation,
-				Prompt:         request.Prompt,
-				WebpageContext: request.WebpageContext,
-				ImageURL:       request.ImageURL,
-			})
+		messageCh := sydneyAPI.AskStream(sydney.AskStreamOptions{
+			StopCtx:        r.Context(),
+			Conversation:   request.Conversation,
+			Prompt:         request.Prompt,
+			WebpageContext: request.WebpageContext,
+			ImageURL:       request.ImageURL,
+		})
 
 		// set headers
 		w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
This pull request makes `conversation` field optional in `ChatStreamRequest`, and the server will automatically create new conversation if the field is absent.