### PR TITLE
[WebAPI] Find most recent user message when processing messages for requests.

### DIFF
--- a/webapi/openai.go
+++ b/webapi/openai.go
@@ -19,10 +19,23 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 	}
 
 	// last message must be user prompt
-	lastMessage := messages[len(messages)-1]
-	prompt, imageUrl := ParseOpenAIMessageContent(lastMessage.Content)
+	var index int
+	var lastMessage OpenAIMessage
 
-	if lastMessage.Role != "user" || prompt == "" {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			index = i
+			lastMessage = messages[i]
+			break
+		}
+	}
+	// exclude the lastMessage from the array
+	messages = append(messages[:index], messages[index+1:]...)
+	
+	//lastMessage := messages[len(messages)-1]
+	prompt, imageUrl := ParseOpenAIMessageContent(lastMessage.Content)
+	
+	if prompt == "" {
 		return OpenAIMessagesParseResult{}, ErrMissingPrompt
 	}
 
@@ -36,8 +49,8 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 	// construct context
 	var contextBuilder strings.Builder
 	contextBuilder.WriteString("\n\n")
-
-	for i, message := range messages[:len(messages)-1] {
+	
+	for i, message := range messages[:len(messages)] {
 		// assert types
 		text, _ := ParseOpenAIMessageContent(message.Content)
 
@@ -55,7 +68,7 @@ func ParseOpenAIMessages(messages []OpenAIMessage) (OpenAIMessagesParseResult, e
 
 		// append content to context
 		contextBuilder.WriteString(text)
-		if i != len(messages)-2 {
+		if i != len(messages)-1 {
 			contextBuilder.WriteString("\n\n")
 		}
 	}


### PR DESCRIPTION
Opening a pull request with the code changes from #173.

This PR makes it so that it searches the provided list of messages, finds the latest user message and then uses that as the prompt.

As long as a user message is present, it will find the most recent one and use that as the lastMessage. It then removes that from the list and recreates the rest of the context as normal. That way if the order is:

```
assistant: How can I help you?
user: Answer this question?
assistant: Here's an answer.
user: Cool, here's a followup question.
system: Answer any questions like a pirate.
```

The code in this PR will find "Cool, here's a followup question" and use that as the Prompt. It will then look like this:

`parsedMessages.Prompt`:
```
Cool, here's a followup question
```

`parsedMessages.WebpageContext`:
```
[assistant](#message)
How can I help you?

[user](#message)
Answer this question?

[assistant](#message)
Here's an answer.

[system](#additional_instructions)
Answer the any questions like a pirate.
```