### PR TITLE
[WebAPI] Allow passing a path to ParseCookies

### DIFF
--- a/webapi/util.go
+++ b/webapi/util.go
@@ -2,15 +2,43 @@ package main
 
 import (
 	"strings"
+	"io/ioutil"
+	"fmt"
+	"encoding/json"
 )
 
 func ParseCookies(cookiesStr string) map[string]string {
 	cookies := map[string]string{}
+	
+	if strings.HasSuffix(cookiesStr, ".json") {
+		data, err := ioutil.ReadFile(cookiesStr)
+		if err != nil {
+			fmt.Println("error:", err)
+		}
+
+		type Item struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		}
+
+		var items []Item
+		err = json.Unmarshal(data, &items)
+		if err != nil {
+			fmt.Println(err)
+		}
+		
+		for _, item := range items {
+        	cookies[item.Name] = item.Value
+    	}
+	} else {
+		
 	for _, cookie := range strings.Split(cookiesStr, ";") {
 		parts := strings.Split(cookie, "=")
 		if len(parts) == 2 {
 			cookies[parts[0]] = parts[1]
 		}
+	}	
 	}
+	
 	return cookies
 }

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -2,46 +2,50 @@ package main
 
 import (
 	"strings"
-	"io/ioutil"
-	"fmt"
 	"encoding/json"
 	"os"
+	"errors"
 )
+
+type FileCookie struct {
+	Domain         string      `json:"domain"`
+	ExpirationDate float64     `json:"expirationDate"`
+	HostOnly       bool        `json:"hostOnly"`
+	HttpOnly       bool        `json:"httpOnly"`
+	Name           string      `json:"name"`
+	Path           string      `json:"path"`
+	SameSite       string      `json:"sameSite"`
+	Secure         bool        `json:"secure"`
+	Session        bool        `json:"session"`
+	StoreId        interface{} `json:"storeId"`
+	Value          string      `json:"value"`
+}
+
+func ReadCookiesFile() (map[string]string, error) {
+	res := map[string]string{}
+	v, err := os.ReadFile("cookies.json")
+	if err != nil {
+		return res, err
+	}
+	var cookies []FileCookie
+	err = json.Unmarshal(v, &cookies)
+	if err != nil {
+		return res, errors.New("failed to json.Unmarshal content of cookie file")
+	}
+	for _, cookie := range cookies {
+		res[cookie.Name] = cookie.Value
+	}
+	return res, nil
+}
 
 func ParseCookies(cookiesStr string) map[string]string {
 	cookies := map[string]string{}
-	
-	// use the os.Stat function to make sure the file exists and make sure it points to a .json file
-	// else load it is a cookieString from a header
-	if _, err := os.Stat(cookiesStr); err == nil && strings.HasSuffix(cookiesStr, ".json") {
-		data, err := ioutil.ReadFile(cookiesStr)
-		if err != nil {
-			fmt.Println("error:", err)
-		}
-
-		type Item struct {
-			Name  string `json:"name"`
-			Value string `json:"value"`
-		}
-
-		var items []Item
-		err = json.Unmarshal(data, &items)
-		if err != nil {
-			fmt.Println(err)
-		}
-		
-		for _, item := range items {
-			cookies[item.Name] = item.Value
-		}
-	} else {
-		for _, cookie := range strings.Split(cookiesStr, ";") {
-			parts := strings.Split(cookie, "=")
-			if len(parts) == 2 {
-			cookies[parts[0]] = parts[1]
-			}
+	for _, cookie := range strings.Split(cookiesStr, ";") {
+		parts := strings.Split(cookie, "=")
+		if len(parts) == 2 {
+		cookies[parts[0]] = parts[1]
 		}
 	}
-
 	
 	return cookies
 }

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -2,41 +2,7 @@ package main
 
 import (
 	"strings"
-	"encoding/json"
-	"os"
-	"errors"
 )
-
-type FileCookie struct {
-	Domain         string      `json:"domain"`
-	ExpirationDate float64     `json:"expirationDate"`
-	HostOnly       bool        `json:"hostOnly"`
-	HttpOnly       bool        `json:"httpOnly"`
-	Name           string      `json:"name"`
-	Path           string      `json:"path"`
-	SameSite       string      `json:"sameSite"`
-	Secure         bool        `json:"secure"`
-	Session        bool        `json:"session"`
-	StoreId        interface{} `json:"storeId"`
-	Value          string      `json:"value"`
-}
-
-func ReadCookiesFile() (map[string]string, error) {
-	res := map[string]string{}
-	v, err := os.ReadFile("cookies.json")
-	if err != nil {
-		return res, err
-	}
-	var cookies []FileCookie
-	err = json.Unmarshal(v, &cookies)
-	if err != nil {
-		return res, errors.New("failed to json.Unmarshal content of cookie file")
-	}
-	for _, cookie := range cookies {
-		res[cookie.Name] = cookie.Value
-	}
-	return res, nil
-}
 
 func ParseCookies(cookiesStr string) map[string]string {
 	cookies := map[string]string{}
@@ -46,6 +12,5 @@ func ParseCookies(cookiesStr string) map[string]string {
 			cookies[parts[0]] = parts[1]
 		}
 	}
-	
 	return cookies
 }

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -43,7 +43,7 @@ func ParseCookies(cookiesStr string) map[string]string {
 	for _, cookie := range strings.Split(cookiesStr, ";") {
 		parts := strings.Split(cookie, "=")
 		if len(parts) == 2 {
-		cookies[parts[0]] = parts[1]
+			cookies[parts[0]] = parts[1]
 		}
 	}
 	

--- a/webapi/util.go
+++ b/webapi/util.go
@@ -5,12 +5,15 @@ import (
 	"io/ioutil"
 	"fmt"
 	"encoding/json"
+	"os"
 )
 
 func ParseCookies(cookiesStr string) map[string]string {
 	cookies := map[string]string{}
 	
-	if strings.HasSuffix(cookiesStr, ".json") {
+	// use the os.Stat function to make sure the file exists and make sure it points to a .json file
+	// else load it is a cookieString from a header
+	if _, err := os.Stat(cookiesStr); err == nil && strings.HasSuffix(cookiesStr, ".json") {
 		data, err := ioutil.ReadFile(cookiesStr)
 		if err != nil {
 			fmt.Println("error:", err)
@@ -28,17 +31,17 @@ func ParseCookies(cookiesStr string) map[string]string {
 		}
 		
 		for _, item := range items {
-        	cookies[item.Name] = item.Value
-    	}
-	} else {
-		
-	for _, cookie := range strings.Split(cookiesStr, ";") {
-		parts := strings.Split(cookie, "=")
-		if len(parts) == 2 {
-			cookies[parts[0]] = parts[1]
+			cookies[item.Name] = item.Value
 		}
-	}	
+	} else {
+		for _, cookie := range strings.Split(cookiesStr, ";") {
+			parts := strings.Split(cookie, "=")
+			if len(parts) == 2 {
+			cookies[parts[0]] = parts[1]
+			}
+		}
 	}
+
 	
 	return cookies
 }

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -35,7 +35,13 @@ func main() {
 
 	noLog := os.Getenv("NO_LOG") != ""
 
-	defaultCookies := ParseCookies(os.Getenv("DEFAULT_COOKIES"))
+	var defaultCookies map[string]string
+	var err error
+	defaultCookies, err = ReadCookiesFile()
+	if err != nil {
+		fmt.Println("NOTICE: Cookie file not found, using enviroment variable")
+		defaultCookies = ParseCookies(os.Getenv("DEFAULT_COOKIES"))
+	}
 
 	authToken := os.Getenv("AUTH_TOKEN")
 

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -35,12 +35,9 @@ func main() {
 
 	noLog := os.Getenv("NO_LOG") != ""
 
-	var defaultCookies map[string]string
-	var err error
-	defaultCookies, err = ReadCookiesFile()
-	if err != nil {
-		fmt.Println("NOTICE: Cookie file not found, using enviroment variable")
-		defaultCookies = ParseCookies(os.Getenv("DEFAULT_COOKIES"))
+	defaultCookies := ParseCookies(os.Getenv("DEFAULT_COOKIES"))
+	if len(defaultCookies) == 0 {
+		defaultCookies, _ = util.ReadCookiesFile()
 	}
 
 	authToken := os.Getenv("AUTH_TOKEN")


### PR DESCRIPTION
Environment variables are a pain to use on Windows, so here I am. This also allows the webapi to work more like its Desktop counterpart.

Loads a JSON file from disk and puts it into an intermediate struct rather than iterating a map of slices because we really only need the name and value fields from the JSON, I think.

If it needs to load all the extras let me know, but I haven't run into any errors with just the name and value.

Example usage:
```go
defaultCookies := ParseCookies("./path/to/cookies.json")
```